### PR TITLE
Update collectionViewContentHeight to include contentInsets in the calculation

### DIFF
--- a/MONUniformFlowLayout/MONUniformFlowLayout.m
+++ b/MONUniformFlowLayout/MONUniformFlowLayout.m
@@ -234,7 +234,7 @@
     NSInteger lastSection = self.numberOfSections - 1;
     CGFloat height = [self computePositionYInSection:lastSection] + [self getFooterHeightInSection:lastSection] + [self computeTotalInterItemSpacingYInSection:lastSection] + [self computeTotalItemHeightInSection:lastSection];
     
-    return MAX(height, self.collectionView.frame.size.height + 1);
+    return MAX(height, self.collectionView.frame.size.height - self.collectionView.contentInset.top - self.collectionView.contentInset.bottom + 1);
 }
 
 #pragma mark -


### PR DESCRIPTION
I noticed that, when you have just a few items and the `UICollectionView`'s content is less high than the screen, vertical scrolling is still possible. It appears the layout doesn't take the `contentInsets` into account.

I updated the `collectionViewContentHeight` method to include the `contentInsets` in the calculation.
